### PR TITLE
Remove unnecessary 'stop' parameter from API call

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5108,7 +5108,7 @@ async function callLLM(prompt, apiKey, endpoint, model = "gpt-4o") {
     try {
         const response = await fetch(endpoint, {
             method: 'POST', headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
-            body: JSON.stringify({ model: model, messages: [{ role: "user", content: prompt }], temperature: 0.6, max_tokens: 180, stop: null }) // Note: max_tokens might be low for some models/tasks
+            body: JSON.stringify({ model: model, messages: [{ role: "user", content: prompt }], temperature: 0.6, max_tokens: 180 }) // Note: max_tokens might be low for some models/tasks
         });
 
         if (!response.ok) {


### PR DESCRIPTION
Google Gemini gives an error if `null` is provided as the value for `stop` parameter (based on the error, Google seems to expect a string). [As per the official OpenAI docs](https://platform.openai.com/docs/api-reference/chat/create#chat-create-stop), 'stop' already has a default value of `null` and thus is unnecessary to set it; removing the unnecessary parameter gets around the fact that Google's OpenAI compatiblity layer doesn't properly follow the spec.

I don't have my git SSH keys set up on this computer, so my apologies about the EOF newline change that GitHub's web UI added.